### PR TITLE
Updated NAudio.Core references to the latest version as it would throw errors

### DIFF
--- a/NAudio.WindowsMediaFormat/NAudio.WindowsMediaFormat.csproj
+++ b/NAudio.WindowsMediaFormat/NAudio.WindowsMediaFormat.csproj
@@ -19,6 +19,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NAudio.Core" Version="2.0.0" />
+		<PackageReference Include="NAudio.Core" Version="2.2.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
The latest version of the NAudio.Wma package is causing compilation issues with the latest NAudio.Core package, requiring a downgrade of the Core package in order for it to work. I did a simple update of the Core package and everything seems to work now.